### PR TITLE
Get storybook to register the correct types

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -229,5 +229,6 @@ const VisGraph = forwardRef<
     <div style={{ width: '100%', height: '100%' }} ref={container} {...props} />
   );
 });
-
+// Set displayName explicitly as it isn't implicitly set
+VisGraph.displayName = 'VisGraph';
 export default VisGraph;

--- a/src/stories/VisNetwork.story.tsx
+++ b/src/stories/VisNetwork.story.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import VisGraph, { NetworkGraphProps } from '..';
 import { Meta, Story } from '@storybook/react';
+import { __fakeType } from './fakeType';
 
 export default {
   title: 'Basic graph example',
-  component: VisGraph,
+  // storybook doesn't work well with forward ref components
+  component: __fakeType,
 } as Meta;
 
 type StoryProps = NetworkGraphProps;

--- a/src/stories/fakeType.tsx
+++ b/src/stories/fakeType.tsx
@@ -1,0 +1,4 @@
+import React from 'react';
+import { NetworkGraphProps } from '..';
+
+export const __fakeType: React.FC<NetworkGraphProps> = () => null;


### PR DESCRIPTION
Storybook doesn't like forward ref components, so we need to set up a fake type definition in a separate file (it doesn't work if done in the same file)
We also want the component to have the correct display name which it was missing!

![image](https://user-images.githubusercontent.com/19843782/152917161-87d1350b-c155-4843-b398-db9179052d70.png)
