### PR TITLE
Add extra option to make zoom require a modifier key

### DIFF
--- a/src/stories/VisNetwork.story.tsx
+++ b/src/stories/VisNetwork.story.tsx
@@ -38,3 +38,31 @@ NetworkWithClickEvents.args = {
     doubleClick: (params) => console.log(params),
   },
 };
+
+const ZoomKeyTemplate: Story<StoryProps> = (args) => {
+  return (
+    <div>
+      <p> Use {args.zoomKey} to zoom so that scrolling normally works</p>
+      <div
+        style={{
+          width: '520px',
+          height: '250px',
+          border: '1px solid black',
+          overflow: 'auto',
+        }}
+      >
+        <div
+          style={{ width: '500px', height: '500px', border: '1px solid black' }}
+        >
+          <VisGraph {...args} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const ZoomKey = ZoomKeyTemplate.bind({});
+ZoomKey.args = {
+  ...BasicNetwork.args,
+  zoomKey: 'ctrlKey',
+};


### PR DESCRIPTION
An extra functionality that I set up internally which allows for preventing zoom without a specified modifier.
I honestly have no idea at this point where I found the approach to do this anymore