### PR TITLE
`autoResize` option enabled

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -89,7 +89,7 @@ const defaultOptions = {
   physics: {
     stabilization: false,
   },
-  autoResize: false,
+  autoResize: true,
   edges: {
     smooth: false,
     color: '#000000',
@@ -103,25 +103,6 @@ const defaultOptions = {
   },
 };
 
-function useResizeObserver(
-  ref: React.MutableRefObject<HTMLElement | null>,
-  callback: ResizeObserverCallback
-): void {
-  useEffect(() => {
-    // Create an observer instance linked to the callback function
-    if (ref.current) {
-      const observer = new ResizeObserver(callback);
-
-      // Start observing the target node for configured mutations
-      observer.observe(ref.current);
-
-      return () => {
-        observer.disconnect();
-      };
-    }
-    return;
-  }, [callback, ref]);
-}
 function shallowClone<T>(array: T[]): T[] {
   return array.map((value) => ({ ...value }));
 }
@@ -237,15 +218,6 @@ const VisGraph = forwardRef<
       newNetwork.destroy();
     };
   }, [edges, initialOptions, nodes]);
-
-  //resize network on window resize
-  function onContainerResize() {
-    if (network) {
-      network.redraw();
-    }
-  }
-
-  useResizeObserver(container, onContainerResize);
 
   return (
     <div style={{ width: '100%', height: '100%' }} ref={container} {...props} />

--- a/src/stories/VisNetwork.story.tsx
+++ b/src/stories/VisNetwork.story.tsx
@@ -21,6 +21,7 @@ const Template: Story<StoryProps> = (args) => {
 
 export const BasicNetwork = Template.bind({});
 BasicNetwork.args = {
+  options: { autoResize: false },
   graph: {
     nodes: [{ id: 1 }, { id: 2 }, { id: 3 }],
     edges: [
@@ -65,4 +66,24 @@ export const ZoomKey = ZoomKeyTemplate.bind({});
 ZoomKey.args = {
   ...BasicNetwork.args,
   zoomKey: 'ctrlKey',
+};
+
+const ResizeTemplate: Story<StoryProps> = (args) => {
+  return (
+    <div
+      style={{
+        resize: 'both',
+        overflow: 'auto',
+        border: '1px solid black',
+      }}
+    >
+      <VisGraph {...args} />
+    </div>
+  );
+};
+
+export const ResizeNetwork = ResizeTemplate.bind({});
+ResizeNetwork.args = {
+  ...BasicNetwork.args,
+  options: { autoResize: true },
 };


### PR DESCRIPTION
Fixes #7 

It's not the prettiest way of doing this (a lot of flashes), but I have another branch I set up with a bunch of changes to enable an external resize-observer approach.

I set `autoResize: true` by default as having it not resize would be a breaking change, unfortunately.

For reference, here's the changes I set up to do the resize-observer approach, and if you decide we should go that route, I'll redo that branch with only the changes needed, and better commit messages. Note, there was a need to surface both the networkRef and the div's ref for this.
https://github.com/Wokstym/react-vis-graph-wrapper/compare/resize-observer